### PR TITLE
Unwrap lines before calling `urlview`

### DIFF
--- a/urlview.tmux
+++ b/urlview.tmux
@@ -13,6 +13,6 @@ get_tmux_option() {
 
 readonly key="$(get_tmux_option "@urlview-key" "u")"
 
-tmux bind-key "$key" capture-pane \\\; \
+tmux bind-key "$key" capture-pane -J \\\; \
   save-buffer /tmp/tmux-buffer \\\; \
   split-window -l 10 "urlview /tmp/tmux-buffer"


### PR DESCRIPTION
tmux-urlview fails to correctly detect line-wrapped URLs and truncates the URL.
This PR adds the -J flag to have tmux join wrapped lines when capturing the
pane contents.

From the `tmux` man page section on `capture-pane`:

```
-J joins wrapped lines and preserves trailing spaces at each line's end.
```
