### PR TITLE
Use $TMPDIR for temp directory

### DIFF
--- a/urlview.tmux
+++ b/urlview.tmux
@@ -14,5 +14,5 @@ get_tmux_option() {
 readonly key="$(get_tmux_option "@urlview-key" "u")"
 
 tmux bind-key "$key" capture-pane \\\; \
-  save-buffer /tmp/tmux-buffer \\\; \
-  split-window -l 10 "urlview /tmp/tmux-buffer"
+  save-buffer "${TMPDIR:-/tmp}/tmux-buffer" \\\; \
+  split-window -l 10 "urlview '${TMPDIR:-/tmp}/tmux-buffer'"


### PR DESCRIPTION
The TMPDIR environment variable should be honored if set, as it may point to
something other than `/tmp` (e.g. `/tmp/.private/$(whoami)` on my system).
Fallback to `/tmp` if `$TMPDIR` is unset or empty.
