### PR TITLE
Remove urlview buffer after dumping to disk

### DIFF
--- a/urlview.tmux
+++ b/urlview.tmux
@@ -15,4 +15,5 @@ readonly key="$(get_tmux_option "@urlview-key" "u")"
 
 tmux bind-key "$key" capture-pane \\\; \
   save-buffer /tmp/tmux-buffer \\\; \
+  delete-buffer \\\; \
   split-window -l 10 "urlview /tmp/tmux-buffer"


### PR DESCRIPTION
The tmux buffer created by `capture-pane` lingers on after it has been
dumped to the disk for urlview.
It should be removed to prevent polluting the user's list of buffers.
