### PR TITLE
Make pane contents reader configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ You should now be able to use the plugin.
 
 Put `set -g @urlview-key 'x'` in `tmux.conf`.
 
+> How can I reverse the order of the URLs?
+
+The program which is used to read the contents of the pane into the URL
+extractor defaults to `cat`, but is configurable. To reverse the order, read
+the contents with `tac` by placing `set -g @urlview-reader 'tac'` in
+`tmux.conf`.
+
 ### Other goodies
 
 `tmux-urlview` works great with:

--- a/urlview.tmux
+++ b/urlview.tmux
@@ -20,9 +20,10 @@ find_executable() {
 }
 
 readonly key="$(get_tmux_option "@urlview-key" "u")"
+readonly reader="$(get_tmux_option "@urlview-reader" "cat")"
 readonly cmd="$(find_executable)"
 
 tmux bind-key "$key" capture-pane -J \\\; \
   save-buffer "${TMPDIR:-/tmp}/tmux-buffer" \\\; \
   delete-buffer \\\; \
-  split-window -l 10 "$cmd '${TMPDIR:-/tmp}/tmux-buffer'"
+  split-window -l 10 "$reader '${TMPDIR:-/tmp}/tmux-buffer' | $cmd"


### PR DESCRIPTION
This changes the plugin so that the contents of the pane are read using an optionally configurable program. The output of the reader is then piped to the URL extractor. The reader defaults to `cat`, which means the default behaviour ends up being exactly the same as what users are currently used to.

Currently this plugin passes the URLs to `urlview`/`extract_url` in the order they appear in the pane. Most of the time the URL I want is at the bottom of the pane (ie, the most recent). I want to reverse the order in which the contents of the pane are sent to the extractor, so I don't have to scroll (as much) in urlview. This can be done by reading the saved pane with `tac` (reverse `cat`, part of coreutils) and piping that to the url extractor. With this change, I can add an option to my `~/.tmux.conf` to make the plugin use `tac` instead of `cat`.
