### PR TITLE
Use sh instead of bash for better portability

### DIFF
--- a/urlview.tmux
+++ b/urlview.tmux
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 get_tmux_option() {
   local option=$1


### PR DESCRIPTION
On a number of systems bash isn't installed, so switch to sh for better portability. I've been using this on OpenBSD for a while without any issues.