### PR TITLE
Allow using an arbitrary program instead of urlview, with command-line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ You should now be able to use the plugin.
 
 Put `set -g @urlview-key 'x'` in `tmux.conf`.
 
+> How can I use the default program FOO to get URLs explicitly?
+
+Put `set -g @urlview-extractor 'FOO'` in `tmux.conf`. The default is
+`urlview` if available, or `extract_url`.
+
+> But I want to run FOO with command-line arguments '-a bar --b baz'!
+
+Fine. Use `set -g @urlview-extractor 'FOO -a bar --b baz'`.
+
 ### Other goodies
 
 `tmux-urlview` works great with:

--- a/urlview.tmux
+++ b/urlview.tmux
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 get_tmux_option() {
   local option=$1

--- a/urlview.tmux
+++ b/urlview.tmux
@@ -21,12 +21,13 @@ find_executable() {
 
 readonly key="$(get_tmux_option "@urlview-key" "u")"
 readonly cmd="$(find_executable)"
+readonly temp_file="$(mktemp --tmpdir tmux-urlview.XXX)"
 
 if [ -z "$cmd" ]; then
   tmux display-message "Failed to load tmux-urlview: neither urlview nor extract_url were found on the PATH"
 else
   tmux bind-key "$key" capture-pane -J \\\; \
-    save-buffer "${TMPDIR:-/tmp}/tmux-buffer" \\\; \
+    save-buffer "$temp_file" \\\; \
     delete-buffer \\\; \
-    split-window -l 10 "$cmd '${TMPDIR:-/tmp}/tmux-buffer'"
+    split-window -l 10 "$cmd '$temp_file'; rm '$temp_file' "
 fi

--- a/urlview.tmux
+++ b/urlview.tmux
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 get_tmux_option() {
   local option=$1
@@ -12,11 +12,24 @@ get_tmux_option() {
 }
 
 find_executable() {
+  local extractor="$(get_tmux_option "@urlview-extractor")"
+  if type "${extractor%% *}" >/dev/null 2>&1; then
+    # FIXME: The %% idiom should work in sh, but it wasn't for me, so I
+    #        reverted the interpreter to bash
+    echo "$extractor"
+    return
+  fi
+  tmux display-message "tmux-urlview: #{@urlview-extractor} not found"
   if type urlview >/dev/null 2>&1; then
     echo "urlview"
-  elif type extract_url >/dev/null 2>&1; then
-    echo "extract_url"
+    return
   fi
+  tmux display-message "tmux-urlview: urlview not found"
+  if type extract_url >/dev/null 2>&1; then
+    echo "extract_url"
+    return
+  fi
+  tmux display-message "tmux-urlview: extract_url not found"
 }
 
 readonly key="$(get_tmux_option "@urlview-key" "u")"
@@ -24,7 +37,7 @@ readonly cmd="$(find_executable)"
 readonly temp_file="$(mktemp --tmpdir tmux-urlview.XXX)"
 
 if [ -z "$cmd" ]; then
-  tmux display-message "Failed to load tmux-urlview: neither urlview nor extract_url were found on the PATH"
+  tmux display-message "Failed to load tmux-urlview: No extractor programs found"
 else
   tmux bind-key "$key" capture-pane -J \\\; \
     save-buffer "$temp_file" \\\; \

--- a/urlview.tmux
+++ b/urlview.tmux
@@ -4,10 +4,10 @@ get_tmux_option() {
   local option=$1
   local default_value=$2
   local option_value=$(tmux show-option -gqv "$option")
-  if [ -z $option_value ]; then
-    echo $default_value
+  if [ -z "$option_value" ]; then
+    echo "$default_value"
   else
-    echo $option_value
+    echo "$option_value"
   fi
 }
 


### PR DESCRIPTION
Many people prefer `urlscan` to `urlview`, although `urlscan` can be agonizingly slow. The PR also sneaks in "better"(?) error messages.